### PR TITLE
Fix wrong scilly vrm bones structure.

### DIFF
--- a/scillia.npc
+++ b/scillia.npc
@@ -1,7 +1,7 @@
 {
   "name": "Scillia",
   "previewUrl": "./images/characters/upstreet/small/scillia.png",
-  "avatarUrl": "./avatars/scilly_drophunter_v31.7_fuji.vrm",
+  "avatarUrl": "./avatars/scilly_drophunter_v31.9_Guilty.vrm",
   "voice": "Sweetie Belle",
   "voicePack": "ShiShi voice pack",
   "class": "Drop Hunter",


### PR DESCRIPTION
Sibling PR: https://github.com/upstreet-labs/app/pull/206

This problem has been fixed before in https://github.com/webaverse/app/pull/3010
But wrong again after that blinking fixing pr https://github.com/webaverse/app/pull/3607

Now the vrm in this pr fixed both of these problems.

<details>
<summary>Wrong:</summary>

https://user-images.githubusercontent.com/10785634/197485520-ef97c63f-8d52-41e0-845d-29744927e5f8.mp4
</details>

Correct:


https://user-images.githubusercontent.com/10785634/197486007-51e99e64-8f22-4801-a425-f3a4c410ce4b.mp4

The landing animation restored to correct version too, should fixed stiffness/non-smooth issue.